### PR TITLE
Change gunicorn worker_class from default sync to gthread

### DIFF
--- a/data/gunicorn.conf.py
+++ b/data/gunicorn.conf.py
@@ -1,6 +1,10 @@
 # For more settings, see: https://docs.gunicorn.org/en/stable/settings.html
 
+import multiprocessing
+
 workers = 1
 worker_connections = 100
 bind = ":8050"
 timeout = 30
+worker_class = "gthread"
+threads = 2 * multiprocessing.cpu_count() + 1  # this formula is suggested in gunicorn docs

--- a/data/gunicorn.conf.py
+++ b/data/gunicorn.conf.py
@@ -6,5 +6,7 @@ workers = 1
 worker_connections = 100
 bind = ":8050"
 timeout = 30
+# Worker is changed to prevent worker timeouts
+# See: https://github.com/benoitc/gunicorn/issues/1801#issuecomment-585886471
 worker_class = "gthread"
 threads = 2 * multiprocessing.cpu_count() + 1  # this formula is suggested in gunicorn docs


### PR DESCRIPTION
KNTK-265
This fixes gunicorn worker timeout problem described here: https://github.com/benoitc/gunicorn/issues/1801