### PR TITLE
Make the matrix view to auto-resize.

### DIFF
--- a/data/assets/03_global.css
+++ b/data/assets/03_global.css
@@ -43,10 +43,8 @@ h3 {
 
 /* Space containing all the elements, as opposed to the unused space on the left and right side */
 .main_container{
+  height: 100vh;
   text-align: center;
-  width: 60vw;
-  min-width: 900px;
   padding: 30px;
-  margin:auto;
   background-color: var(--white-0);
 }

--- a/data/assets/05_dash-graph.css
+++ b/data/assets/05_dash-graph.css
@@ -3,7 +3,14 @@
 
 /* Connection matrix */
 .chart__default {
-  display: flex;
-  align-content: center;
-  justify-content: center;
+  	align-content: center;
+  	justify-content: center
+    width: 70vw;
+	height: 70vh;
+}
+.chart_container {
+	height: 70vh;
+}
+#matrix.dash-graph {
+	height: 70vh;
 }

--- a/domain/cached_repo_request_driven.py
+++ b/domain/cached_repo_request_driven.py
@@ -16,7 +16,7 @@ class CachedRepoRequestDriven:
     when the data is requested and cache is older than 'max_data_age_seconds'
     """
 
-    TIMESTAMP_NEVER_UPDATED = datetime(1970, 1, 1).replace(tzinfo=timezone.utc)
+    TIMESTAMP_NEVER_UPDATED = datetime(year=1970, month=1, day=1, tzinfo=timezone.utc)
 
     def __init__(
         self,

--- a/presentation/localtime.py
+++ b/presentation/localtime.py
@@ -2,4 +2,4 @@ from datetime import datetime, timezone
 
 
 def utc_to_localtime(time: datetime) -> datetime:
-    return time.replace(tzinfo=timezone.utc).astimezone(tz=None)
+    return time.astimezone(tz=None)

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -48,7 +48,7 @@ class MatrixView:
                     children=[
                         html.H2(
                             children=[
-                                html.Span("Data timestamp"),
+                                html.Span("Last update: "),
                                 html.Span(
                                     timestamp, className="header-timestamp", id="current-timestamp", title=timestampISO
                                 ),
@@ -81,7 +81,7 @@ class MatrixView:
                         html.Div(
                             children=[
                                 html.Div(
-                                    dcc.Graph(id=self.MATRIX, style={"width": 900, "height": 750}, figure=fig),
+                                    dcc.Graph(id=self.MATRIX, figure=fig, responsive=True),
                                     className="chart__default",
                                 ),
                                 html.Div(
@@ -123,13 +123,14 @@ class MatrixView:
         data = self.make_figure_data(mesh, metric)
         annotations = self.make_figure_annotations(mesh, metric)
         layout = dict(
-            margin=dict(l=150, b=50, t=100, r=50),
+            margin=dict(l=200, b=0, t=100, r=0),
             modebar={"orientation": "v"},
             annotations=annotations,
             xaxis=dict(side="top", ticks="", scaleanchor="y"),
             yaxis=dict(side="left", ticks=""),
             hovermode="closest",
             showlegend=False,
+            autosize=True,
         )
 
         return {"data": [data], "layout": layout}
@@ -149,6 +150,7 @@ class MatrixView:
             name="",
             showscale=False,
             colorscale=self.make_color_scale(sla_levels),
+            autosize=True,
         )
 
     def make_sla_levels(self, mesh: MeshResults, metric: MetricType) -> List[SLALevelColumn]:
@@ -208,10 +210,10 @@ class MatrixView:
     @staticmethod
     def get_text(metric: MetricType, cell: MeshColumn) -> str:
         if metric == MetricType.LATENCY:
-            return f"<b>{(cell.latency_millisec.value):.2f} ms</b>"
+            return f"{(cell.latency_millisec.value):.2f}"
         if metric == MetricType.JITTER:
-            return f"<b>{(cell.jitter_millisec.value):.2f} ms</b>"
-        return f"<b>{cell.packet_loss_percent.value:.1f}%</b>"
+            return f"{(cell.jitter_millisec.value):.2f}"
+        return f"{cell.packet_loss_percent.value:.1f}"
 
     def make_hover_text(self, mesh: MeshResults) -> List[List[str]]:
         text = []


### PR DESCRIPTION
Allow larger matrices to be displayed by removing units and bold font from matrix cells.
Simplify conversion of UTC time to local time and construction of the "never udpated"
timestamp.