### PR TITLE
Data ordering fix (KNTK-280)

### DIFF
--- a/data/assets/03_global.css
+++ b/data/assets/03_global.css
@@ -43,10 +43,8 @@ h3 {
 
 /* Space containing all the elements, as opposed to the unused space on the left and right side */
 .main_container{
+  height: 100vh;
   text-align: center;
-  width: 60vw;
-  min-width: 900px;
   padding: 30px;
-  margin:auto;
   background-color: var(--white-0);
 }

--- a/data/assets/05_dash-graph.css
+++ b/data/assets/05_dash-graph.css
@@ -3,7 +3,14 @@
 
 /* Connection matrix */
 .chart__default {
-  display: flex;
-  align-content: center;
-  justify-content: center;
+  	align-content: center;
+  	justify-content: center
+    width: 70vw;
+	height: 70vh;
+}
+.chart_container {
+	height: 70vh;
+}
+#matrix.dash-graph {
+	height: 70vh;
 }

--- a/domain/cached_repo_request_driven.py
+++ b/domain/cached_repo_request_driven.py
@@ -16,7 +16,7 @@ class CachedRepoRequestDriven:
     when the data is requested and cache is older than 'max_data_age_seconds'
     """
 
-    TIMESTAMP_NEVER_UPDATED = datetime(1970, 1, 1).replace(tzinfo=timezone.utc)
+    TIMESTAMP_NEVER_UPDATED = datetime(year=1970, month=1, day=1, tzinfo=timezone.utc)
 
     def __init__(
         self,

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 from domain.geo import Coordinates
@@ -116,9 +116,6 @@ class MeshResults:
         rows: Optional[List[MeshRow]] = None,
         agents: Agents = Agents(),
     ) -> None:
-        if utc_timestamp is None:
-            utc_timestamp = datetime.now(timezone.utc)
-
         self.utc_timestamp = utc_timestamp
         if rows is not None:
             self.rows = sorted(rows, key=lambda x: x.agent_id)

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -43,7 +43,7 @@ class Agents:
 
 @dataclass
 class Metric:
-    """ Represents single from->to connection metric """
+    """Represents single from->to connection metric"""
 
     health: str = ""  # "healthy", "warning", ...
     value: MetricValue = MetricValue()
@@ -51,7 +51,7 @@ class Metric:
 
 @dataclass
 class HealthItem:
-    """ Represents single from->to connection health timeseries entry """
+    """Represents single from->to connection health timeseries entry"""
 
     jitter_millisec: MetricValue
     latency_millisec: MetricValue
@@ -61,7 +61,7 @@ class HealthItem:
 
 @dataclass
 class MeshColumn:
-    """ Represents connection "to" endpoint """
+    """Represents connection "to" endpoint"""
 
     agent_id: AgentID = AgentID()
     jitter_millisec: Metric = Metric()
@@ -74,7 +74,8 @@ class MeshColumn:
 
 
 class MeshRow:
-    """ Represents connection "from" endpoint """
+    """Represents connection "from" endpoint"""
+
     def __init__(self, agent_id: AgentID, columns: List[MeshColumn]):
         self.agent_id = agent_id
         self.columns = sorted(columns, key=lambda x: x.agent_id)

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -20,9 +20,9 @@ class Agents:
     def __init__(self) -> None:
         self._agents: Dict[AgentID, Agent] = {}
 
-    def get_by_id(self, id: AgentID) -> Agent:
-        if id in self._agents:
-            return self._agents[id]
+    def get_by_id(self, agent_id: AgentID) -> Agent:
+        if agent_id in self._agents:
+            return self._agents[agent_id]
         return Agent()
 
     def get_by_alias(self, alias: str) -> Agent:
@@ -31,10 +31,10 @@ class Agents:
                 return v
         return Agent()
 
-    def get_alias(self, id: AgentID) -> str:
-        agent = self.get_by_id(id)
+    def get_alias(self, agent_id: AgentID) -> str:
+        agent = self.get_by_id(agent_id)
         if agent.id == AgentID():
-            return f"[agent_id={id} not found]"
+            return f"[agent_id={agent_id} not found]"
         return agent.alias
 
     def insert(self, agent: Agent) -> None:
@@ -73,12 +73,11 @@ class MeshColumn:
         return self.packet_loss_percent.value == MetricValue(100) or self.health == []
 
 
-@dataclass
 class MeshRow:
     """ Represents connection "from" endpoint """
-
-    agent_id: AgentID
-    columns: List[MeshColumn]
+    def __init__(self, agent_id: AgentID, columns: List[MeshColumn]):
+        self.agent_id = agent_id
+        self.columns = sorted(columns, key=lambda x: x.agent_id)
 
 
 class ConnectionMatrix:
@@ -105,21 +104,27 @@ class ConnectionMatrix:
 
 
 class MeshResults:
-    """Internal representation of Mesh Test results; independent of source data structure like http or grpc synthetics client"""
+    """
+    Internal representation of Mesh Test results; independent of source data structure like http
+    or grpc synthetics client
+    """
 
     def __init__(
         self,
-        utc_timestamp: Optional[datetime] = None,
-        rows: List[MeshRow] = [],
+        utc_timestamp: datetime,
+        rows: Optional[List[MeshRow]] = None,
         agents: Agents = Agents(),
     ) -> None:
         if utc_timestamp is None:
             utc_timestamp = datetime.now(timezone.utc)
 
         self.utc_timestamp = utc_timestamp
-        self.rows = rows
+        if rows is not None:
+            self.rows = sorted(rows, key=lambda x: x.agent_id)
+        else:
+            self.rows = []
         self.agents = agents
-        self._connection_matrix = ConnectionMatrix(rows)
+        self._connection_matrix = ConnectionMatrix(self.rows)
 
     def filter(self, from_agent, to_agent: AgentID, metric: MetricType) -> List[Tuple[datetime, MetricValue]]:
         items = self.connection(from_agent, to_agent).health

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+ignore_missing_imports = True
+exclude = /generated/
+
+[mypy-generated.*]
+ignore_errors = True

--- a/presentation/chart_view.py
+++ b/presentation/chart_view.py
@@ -88,7 +88,9 @@ class ChartView:
     ):
         filtered = mesh.filter(from_agent, to_agent, metric)
         xdata, ydata = zip(*filtered) if filtered else ((), ())
-        layout = go.Layout(margin={"t": 0, "b": 0})  # remove empty space above and below the chart
+        layout = go.Layout(
+            margin={"t": 0, "b": 0},   # remove empty space above and below the chart
+            modebar={"orientation": "v"})
         fig = go.Figure(
             data=[go.Scatter(x=xdata, y=ydata)],
             layout=layout,

--- a/presentation/chart_view.py
+++ b/presentation/chart_view.py
@@ -89,8 +89,8 @@ class ChartView:
         filtered = mesh.filter(from_agent, to_agent, metric)
         xdata, ydata = zip(*filtered) if filtered else ((), ())
         layout = go.Layout(
-            margin={"t": 0, "b": 0},   # remove empty space above and below the chart
-            modebar={"orientation": "v"})
+            margin={"t": 0, "b": 0}, modebar={"orientation": "v"}  # remove empty space above and below the chart
+        )
         fig = go.Figure(
             data=[go.Scatter(x=xdata, y=ydata)],
             layout=layout,

--- a/presentation/localtime.py
+++ b/presentation/localtime.py
@@ -2,4 +2,4 @@ from datetime import datetime, timezone
 
 
 def utc_to_localtime(time: datetime) -> datetime:
-    return time.replace(tzinfo=timezone.utc).astimezone(tz=None)
+    return time.astimezone(tz=None)

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -20,6 +20,7 @@ from domain.types import AgentID, MetricValue, Threshold
 # We make sure to always have values in range [0.0 - 1.0] in our matrix,
 # so that no range stretching occurs and coloring works as expected.
 
+
 # SLALevel maps connection state to a value in connection matrix, in range [0.0 - 1.0]
 class SLALevel(float, Enum):
     _MIN = 0.0
@@ -152,12 +153,12 @@ class MatrixView:
         return {"data": [data], "layout": layout}
 
     def make_figure_data(self, mesh: MeshResults, metric: MetricType) -> Dict:
-        labels = [mesh.agents.get_by_id(row.agent_id).alias for row in mesh.rows]
-        reversed_labels = list(reversed(labels))
+        x_labels = [mesh.agents.get_by_id(row.agent_id).alias for row in mesh.rows]
+        y_labels = list(reversed(x_labels))
         sla_levels = self.make_sla_levels(mesh, metric)
         return dict(
-            x=labels,
-            y=reversed_labels,
+            x=x_labels,
+            y=y_labels,
             z=sla_levels,
             text=self.make_hover_text(mesh),
             type="heatmap",

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -54,7 +54,7 @@ class MatrixView:
                     children=[
                         html.H2(
                             children=[
-                                html.Span("Data timestamp"),
+                                html.Span("Last update: "),
                                 html.Span(
                                     "<test_results_date_time>",
                                     className="header-timestamp",
@@ -90,7 +90,7 @@ class MatrixView:
                         html.Div(
                             children=[
                                 html.Div(
-                                    dcc.Graph(id=self.MATRIX, style={"width": 900, "height": 750}, figure=fig),
+                                    dcc.Graph(id=self.MATRIX, figure=fig, responsive=True),
                                     className="chart__default",
                                 ),
                                 html.Div(
@@ -139,13 +139,14 @@ class MatrixView:
         data = self.make_figure_data(mesh, metric)
         annotations = self.make_figure_annotations(mesh, metric)
         layout = dict(
-            margin=dict(l=150, b=50, t=100, r=50),
+            margin=dict(l=200, b=0, t=100, r=0),
             modebar={"orientation": "v"},
             annotations=annotations,
             xaxis=dict(side="top", ticks="", scaleanchor="y"),
             yaxis=dict(side="left", ticks=""),
             hovermode="closest",
             showlegend=False,
+            autosize=True,
         )
 
         return {"data": [data], "layout": layout}
@@ -165,6 +166,7 @@ class MatrixView:
             name="",
             showscale=False,
             colorscale=self.make_color_scale(),
+            autosize=True,
         )
 
     def make_sla_levels(self, mesh: MeshResults, metric: MetricType) -> List[SLALevelColumn]:
@@ -229,10 +231,10 @@ class MatrixView:
     @staticmethod
     def get_text(metric: MetricType, cell: MeshColumn) -> str:
         if metric == MetricType.LATENCY:
-            return f"<b>{(cell.latency_millisec.value):.2f} ms</b>"
+            return f"{(cell.latency_millisec.value):.2f}"
         if metric == MetricType.JITTER:
-            return f"<b>{(cell.jitter_millisec.value):.2f} ms</b>"
-        return f"<b>{cell.packet_loss_percent.value:.1f}%</b>"
+            return f"{(cell.jitter_millisec.value):.2f}"
+        return f"{cell.packet_loss_percent.value:.1f}"
 
     def make_hover_text(self, mesh: MeshResults) -> List[List[str]]:
         matrix_hover_text: List[List[str]] = []

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -166,6 +166,7 @@ class MatrixView:
             opacity=1,
             name="",
             showscale=False,
+            autosize=True,
             colorscale=self.make_color_scale(),
             autosize=True,
         )

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -168,7 +168,6 @@ class MatrixView:
             showscale=False,
             autosize=True,
             colorscale=self.make_color_scale(),
-            autosize=True,
         )
 
     def make_sla_levels(self, mesh: MeshResults, metric: MetricType) -> List[SLALevelColumn]:


### PR DESCRIPTION
Fixes the problem reported in the ticket by ordering columns in MeshRow instances and rows in MeshResults by agent ID.
Also includes:
- orienting Plotly toolbar vertically in time series view (in order to allow clicking on the right most point in the chart)
- minor style and formatting fixes to make black and PyCharm happy

The pull request is built on top of  matrix resizing fixes (https://github.com/kentik/sla_dashboard_webapp/pull/38).