### PR TITLE
List agents only when necessary

### DIFF
--- a/domain/cached_repo_request_driven.py
+++ b/domain/cached_repo_request_driven.py
@@ -41,14 +41,14 @@ class CachedRepoRequestDriven:
         if self._cached_data_fresh_enough():
             return
 
-        logger.debug("Updating data cache start...")
+        logger.debug("Updating mesh test results cache")
         try:
             results = self._source_repo.get_mesh_test_results(self._test_id, self._lookback_seconds)
             with self._cache_access_lock:
                 self._cache_test_results = results
-            logger.debug("Updating data cache successful")
-        except Exception as err:
-            logger.exception("Updating data cache error")
+            logger.debug("Finished updating mesh test results cache")
+        except Exception:
+            logger.exception("Failed to update mesh test results cache")
 
     def _cached_data_fresh_enough(self) -> bool:
         max_age = timedelta(seconds=self._max_data_age_seconds)

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
@@ -20,6 +21,9 @@ class Agents:
     def __init__(self) -> None:
         self._agents: Dict[AgentID, Agent] = {}
 
+    def insert(self, agent: Agent) -> None:
+        self._agents[agent.id] = agent
+
     def get_by_id(self, agent_id: AgentID) -> Agent:
         if agent_id in self._agents:
             return self._agents[agent_id]
@@ -37,8 +41,14 @@ class Agents:
             return f"[agent_id={agent_id} not found]"
         return agent.alias
 
-    def insert(self, agent: Agent) -> None:
-        self._agents[agent.id] = agent
+    def list_agent_ids(self) -> List[AgentID]:
+        return list(self._agents)
+
+    def filter(self, agent_ids: List[AgentID]):
+        result = Agents()
+        for agent_id in agent_ids:
+            result.insert(deepcopy(self.get_by_id(agent_id)))
+        return result
 
 
 @dataclass


### PR DESCRIPTION
To avoid listing agents on every get_mesh_test_results() call, agents are
cached as a field of SyntheticsRepo. Agents cache is updated only when
necessary.

Issue: KNTK-290
