### PR TITLE
Add units back to labels in the primary metric drop-down box

### DIFF
--- a/domain/metric.py
+++ b/domain/metric.py
@@ -7,6 +7,14 @@ MetricValue = float
 """ latency and jitter in milliseconds, packet_loss in percent (0-100) """
 
 
+class MetricUnit(Enum):
+    """Measurement units for mesh test metrics"""
+
+    LATENCY = "ms"
+    JITTER = "ms"
+    PACKET_LOSS = "%"
+
+
 class MetricType(Enum):
     """Available mesh test metric types"""
 
@@ -14,21 +22,18 @@ class MetricType(Enum):
     JITTER = "Jitter"
     PACKET_LOSS = "Packet loss"
 
+    @property
+    def unit(self) -> str:
+        return MetricUnit.__getattr__(self.name).value  # type: ignore
+
 
 @dataclass
 class Metric:
+    """Representation of single test metric"""
+
     type: MetricType
     value: MetricValue
-    unit: str
 
-    @classmethod
-    def latency(cls, value: MetricValue, unit: str = "ms") -> Metric:
-        return cls(MetricType.LATENCY, value, unit)
-
-    @classmethod
-    def jitter(cls, value: MetricValue, unit: str = "ms") -> Metric:
-        return cls(MetricType.JITTER, value, unit)
-
-    @classmethod
-    def loss(cls, value: MetricValue, unit: str = "%") -> Metric:
-        return cls(MetricType.PACKET_LOSS, value, unit)
+    @property
+    def unit(self) -> str:
+        return self.type.unit

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -52,16 +52,24 @@ class Agents:
 class HealthItem:
     """Represents single from->to connection health time-series entry"""
 
-    def __init__(self, jitter_millisec, latency_millisec, packet_loss_percent: MetricValue, time: datetime) -> None:
+    def __init__(
+        self,
+        jitter_millisec: MetricValue,
+        latency_millisec: MetricValue,
+        packet_loss_percent: MetricValue,
+        time: datetime,
+    ) -> None:
         self.timestamp = time
-        self.packet_loss_percent = Metric.loss(packet_loss_percent)
+        self.packet_loss_percent = Metric(type=MetricType.PACKET_LOSS, value=packet_loss_percent)
 
         # if packet loss is 100%, then jitter and latency measurements do not apply
-        self.jitter_millisec = Metric.jitter(
-            jitter_millisec if packet_loss_percent < MetricValue(100) else MetricValue("nan")
+        self.jitter_millisec = Metric(
+            type=MetricType.JITTER,
+            value=jitter_millisec if packet_loss_percent < MetricValue(100) else MetricValue("nan"),
         )
-        self.latency_millisec = Metric.latency(
-            latency_millisec if packet_loss_percent < MetricValue(100) else MetricValue("nan")
+        self.latency_millisec = Metric(
+            type=MetricType.LATENCY,
+            value=latency_millisec if packet_loss_percent < MetricValue(100) else MetricValue("nan"),
         )
 
     def get_metric(self, type: MetricType) -> Metric:

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -80,7 +80,7 @@ class MatrixView:
                                 html.Label("Select primary metric:", className="select_label"),
                                 dcc.Dropdown(
                                     id=self.METRIC_SELECTOR,
-                                    options=[{"label": f"{m.value}", "value": m.value} for m in MetricType],
+                                    options=[{"label": f"{m.value} [{m.unit}]", "value": m.value} for m in MetricType],
                                     value=metric.value,
                                     clearable=False,
                                     className="dropdowns",


### PR DESCRIPTION
 This change further streamlines handling of metrics and their units