### PR TITLE
Tentative fix for KNTK-306 issue

### DIFF
--- a/data/config.yaml
+++ b/data/config.yaml
@@ -12,7 +12,7 @@ data_update_lookback_seconds: 3600
 timeout: [30.0, 30.0]
 
 # sets the logging level. Possible values are: [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-logging_level: INFO
+logging_level: DEBUG
 
 # matrix look
 matrix:

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -12,7 +12,7 @@ data_update_lookback_seconds: 3600
 timeout: [30.0, 30.0]
 
 # sets the logging level. Possible values are: [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-logging_level: DEBUG
+logging_level: INFO
 
 # matrix look
 matrix:

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
-from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timezone
+from typing import Dict, Generator, List, Optional, Tuple
 
 from domain.geo import Coordinates
 from domain.metric import Metric, MetricType, MetricValue
@@ -24,33 +24,43 @@ class Agent:
 class Agents:
     def __init__(self) -> None:
         self._agents: Dict[AgentID, Agent] = {}
+        self._agents_by_name: Dict[str, Agent] = {}
 
     def equals(self, other: Agents) -> bool:
         return self._agents == other._agents
 
     def get_by_id(self, agent_id: AgentID) -> Agent:
-        if agent_id in self._agents:
-            return self._agents[agent_id]
-        return Agent()
+        return self._agents.get(agent_id, Agent())
 
-    def get_by_alias(self, alias: str) -> Agent:
-        for _, v in self._agents.items():
-            if v.alias == alias:
-                return v
-        return Agent()
-
-    def get_alias(self, agent_id: AgentID) -> str:
-        agent = self.get_by_id(agent_id)
-        if agent.id == AgentID():
-            return f"[agent_id={agent_id} not found]"
-        return agent.alias
+    def get_by_name(self, name: str) -> Agent:
+        return self._agents_by_name.get(name, Agent())
 
     def insert(self, agent: Agent) -> None:
         self._agents[agent.id] = agent
+        existing = self._agents_by_name.get(agent.name)
+        if existing:
+            logger.warning("Duplicate agent name '%s' (ids: %s %s)", agent.name, existing.id, agent.id)
+            _dedup_name = "{agent.name} [{agent.id}]"
+            del self._agents_by_name[existing.name]
+            existing.name = _dedup_name.format(agent=existing)
+            self._agents_by_name[existing.name] = existing
+            agent.name = _dedup_name.format(agent=agent)
+        self._agents_by_name[agent.name] = agent
+        logger.debug("adding agent: id: %s name: %s alias: %s", agent.id, agent.name, agent.alias)
 
-    @property
-    def sorted_ids(self) -> List[AgentID]:
-        return sorted(self._agents.keys())
+    def remove(self, agent: Agent):
+        try:
+            del self._agents[agent.id]
+        except KeyError:
+            logger.warning("Agent id: %s name: %s was not in dict by id", agent.id, agent.name)
+        try:
+            del self._agents_by_name[agent.name]
+        except KeyError:
+            logger.warning("Agent id: %s name: %s was not in dict by name", agent.id, agent.name)
+
+    def all(self, reverse: bool = False) -> Generator[Agent, None, None]:
+        for n in sorted(self._agents_by_name.keys(), key=lambda x: x.lower(), reverse=reverse):
+            yield self._agents_by_name[n]
 
 
 class HealthItem:
@@ -76,14 +86,14 @@ class HealthItem:
             value=latency_millisec if packet_loss_percent < MetricValue(100) else MetricValue("nan"),
         )
 
-    def get_metric(self, type: MetricType) -> Metric:
-        if type == MetricType.LATENCY:
+    def get_metric(self, metric_type: MetricType) -> Metric:
+        if metric_type == MetricType.LATENCY:
             return self.latency_millisec
-        if type == MetricType.JITTER:
+        if metric_type == MetricType.JITTER:
             return self.jitter_millisec
-        if type == MetricType.PACKET_LOSS:
+        if metric_type == MetricType.PACKET_LOSS:
             return self.packet_loss_percent
-        raise Exception(f"MetricType not supported: {type}")
+        raise Exception(f"MetricType not supported: {metric_type}")
 
 
 @dataclass
@@ -102,7 +112,7 @@ class MeshColumn:
     def has_data(self) -> bool:
         """
         Determines if there are any observations available for this connection.
-        Lack of observations may be caused by specyfing incorrect time window in tests health request,
+        Lack of observations may be caused by specifying incorrect time window in tests health request,
         or by the test itself being in paused state.
         """
 
@@ -112,9 +122,13 @@ class MeshColumn:
 class MeshRow:
     """Represents connection "from" endpoint"""
 
-    def __init__(self, agent_id: AgentID, columns: List[MeshColumn]):
-        self.agent_id = agent_id
+    def __init__(self, agent: Agent, columns: List[MeshColumn]):
+        self.agent = agent
         self.columns = sorted(columns, key=lambda x: x.agent_id)
+
+    @property
+    def agent_id(self) -> AgentID:
+        return self.agent.id
 
 
 class ConnectionMatrix:
@@ -190,12 +204,36 @@ class MeshResults:
     def __init__(
         self, utc_last_updated: datetime, rows: Optional[List[MeshRow]] = None, agents: Agents = Agents()
     ) -> None:
-
-        # utc_last_updated is when the data was fetched from the server, as opposed to when the data was actually collected.
-        # the latter is a property of MeshColumn
+        # The 'utc_last_updated' timestamp indicates time when data was fetched from the server,
+        # as opposed to when it was actually collected. The latter is property of MeshColumn
         self.utc_last_updated = utc_last_updated
         self.agents = agents
         self.connection_matrix = ConnectionMatrix(rows if rows else [])
+        # temporary fix working around inconsistent agent names returned by the API
+        # 'mesh' rows in augmented test health response currently contain the most usable agent names
+        # so update agents using this data while preserving other attributes retrieved with 'AgentsList'
+        if rows:
+            self._update_agents(rows)
+
+    def _update_agents(self, rows: List[MeshRow]) -> None:
+        """
+        Update agent names and aliases based on row data while preserving other existing agent attributes
+        NOTE: This is an ugly hack that should be removed as soon as Kentik API becomes little bit more consistent
+        """
+        for r in rows:
+            agent = self.agents.get_by_id(r.agent.id)
+            if agent.id == AgentID():
+                agent = r.agent
+                logging.warning("Agent %s (name: %s) was not in cache", agent.id, agent.name)
+                self.agents.insert(agent)
+            else:
+                # We need to preserve other attributes retrieved from AgentsList, so we cannot simply replace the
+                # existing agent. However, we need to delete it from the cache and re-insert it in order to
+                # keep dictionary by name in sync
+                self.agents.remove(agent)
+                agent.name = r.agent.name
+                agent.alias = r.agent.alias
+                self.agents.insert(agent)
 
     def incremental_update(self, src: MeshResults) -> None:
         """Update with src data, add new pieces of data if any, don't remove anything"""
@@ -209,9 +247,9 @@ class MeshResults:
     def can_incremental_update(self, src: MeshResults) -> bool:
         return self.agents.equals(src.agents)
 
-    def filter(self, from_agent, to_agent: AgentID, type: MetricType) -> List[Tuple[datetime, MetricValue]]:
+    def filter(self, from_agent, to_agent: AgentID, metric_type: MetricType) -> List[Tuple[datetime, MetricValue]]:
         items = self.connection(from_agent, to_agent).health
-        return [(i.timestamp, i.get_metric(type).value) for i in items]
+        return [(i.timestamp, i.get_metric(metric_type).value) for i in items]
 
     def connection(self, from_agent, to_agent: AgentID) -> MeshColumn:
         return self.connection_matrix.connection(from_agent, to_agent)

--- a/infrastructure/data_access/http/synthetics_repo.py
+++ b/infrastructure/data_access/http/synthetics_repo.py
@@ -54,13 +54,13 @@ class SyntheticsRepo:
             request, _request_timeout=self._timeout
         )
 
-        # response.health can be an empty list if no measurements were recorded in requested period of time
-        # for example: right after mesh test was started, after mesh test was paused
+        # The response.health list can be empty if no measurements were recorded in the requested time period,
+        # for example, right after mesh test is started, or when it is paused
         if len(response.health) == 0:
             return []
-
-        most_recent_result = response.health[-1]
-        return transform_to_internal_mesh_rows(most_recent_result)
+        # The response.health list contains one entry for each unique test ID passed in the 'ids' list in the request.
+        # We always request results for only one test, so using the first and only item is safe.
+        return transform_to_internal_mesh_rows(response.health[0])
 
     def _get_agents(self, test_id) -> Agents:
         test_resp = self._api_client.synthetics_admin_service.test_get(test_id)
@@ -70,8 +70,11 @@ class SyntheticsRepo:
 
 def transform_to_internal_mesh_rows(data: V202101beta1TestHealth) -> List[MeshRow]:
     rows: List[MeshRow] = []
-    for input_row in data.mesh:
-        row = MeshRow(agent_id=AgentID(input_row.id), columns=transform_to_internal_mesh_columns(input_row.columns))
+    for r in data.mesh:
+        row = MeshRow(
+            agent=Agent(id=AgentID(r.id), name=r.name, alias=r.alias),
+            columns=transform_to_internal_mesh_columns(r.columns),
+        )
         rows.append(row)
     return rows
 

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ class WebApp:
     def _make_matrix_layout(self, path: str) -> html.Div:
         metric = routing.decode_matrix_path(path)
         results = self._cached_repo.get_mesh_test_results()
-        return self._matrix_view.make_layout(results, metric, self._config)
+        return self._matrix_view.make_layout(results, metric)
 
     def _make_chart_layout(self, path: str) -> html.Div:
         from_agent, to_agent = routing.decode_chart_path(path)

--- a/presentation/chart_view.py
+++ b/presentation/chart_view.py
@@ -15,7 +15,7 @@ class ChartView:
     def __init__(self, config: Config) -> None:
         self._config = config
 
-    def make_layout(self, from_agent, to_agent: AgentID, mesh: MeshResults) -> html.Div:
+    def make_layout(self, from_agent: AgentID, to_agent: AgentID, mesh: MeshResults) -> html.Div:
         title = self.make_title(from_agent, to_agent, mesh)
         conn = mesh.connection(from_agent, to_agent)
 
@@ -35,7 +35,7 @@ class ChartView:
     def make_no_data_content() -> List:
         return [html.H1("NO DATA"), html.Br(), html.Br()]
 
-    def make_charts_content(self, from_agent, to_agent: AgentID, mesh: MeshResults) -> List:
+    def make_charts_content(self, from_agent: AgentID, to_agent: AgentID, mesh: MeshResults) -> List:
         fig_latency = self.make_figure(from_agent, to_agent, MetricType.LATENCY, mesh)
         fig_jitter = self.make_figure(from_agent, to_agent, MetricType.JITTER, mesh)
         fig_packetloss = self.make_figure(from_agent, to_agent, MetricType.PACKET_LOSS, mesh, (0, 100))

--- a/presentation/chart_view.py
+++ b/presentation/chart_view.py
@@ -31,7 +31,8 @@ class ChartView:
             ]
         )
 
-    def make_no_data_content(self) -> List:
+    @staticmethod
+    def make_no_data_content() -> List:
         return [html.H1("NO DATA"), html.Br(), html.Br()]
 
     def make_charts_content(self, from_agent, to_agent: AgentID, mesh: MeshResults) -> List:
@@ -48,14 +49,15 @@ class ChartView:
             dcc.Graph(id="timeseries_packetloss_chart", style=style, figure=fig_packetloss),
         ]
 
-    def make_title(self, from_agent, to_agent: AgentID, mesh: MeshResults) -> str:
-        from_alias = mesh.agents.get_alias(from_agent)
-        to_alias = mesh.agents.get_alias(to_agent)
-        from_coords = mesh.agents.get_by_id(from_agent).coords
-        to_coords = mesh.agents.get_by_id(to_agent).coords
+    def make_title(self, from_agent_id: AgentID, to_agent_id: AgentID, mesh: MeshResults) -> str:
+        from_agent = mesh.agents.get_by_id(from_agent_id)
+        to_agent = mesh.agents.get_by_id(to_agent_id)
         distance_unit = self._config.distance_unit
-        distance = calc_distance(from_coords, to_coords, distance_unit)
-        return f"{from_alias} -> {to_alias} ({distance:.0f} {distance_unit.value})"
+        distance = calc_distance(from_agent.coords, to_agent.coords, distance_unit)
+        return (
+            f"{from_agent.name}, {from_agent.alias} [{from_agent.id}] -> "
+            f"{to_agent.name}, {to_agent.alias} [{to_agent.id}] ({distance:.0f} {distance_unit.value})"
+        )
 
     @staticmethod
     def make_figure(

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -1,3 +1,5 @@
+import logging
+
 import math
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
@@ -10,14 +12,14 @@ from domain.config.thresholds import Thresholds
 from domain.geo import calc_distance
 from domain.metric import MetricType, MetricValue
 from domain.model import MeshResults
-from domain.model.mesh_results import Agents, HealthItem
+from domain.model.mesh_results import Agent, Agents, HealthItem
 from domain.types import AgentID, Threshold
 
 # Connections are displayed as a matrix using dcc.Graph component.
 # The Graph is configured as a heatmap.
 # In heatmap, each cell is assigned a floating-point type value.
 # The heatmap itself is assigned a color scale that maps range [0.0 - 1.0] to colors.
-# The heatmap dynamiacally "stretches" it's color scale range to cover all cells values.
+# The heatmap dynamically "stretches" it's color scale range to cover all cells values.
 # We make sure to always have values in range [0.0 - 1.0] in our matrix,
 # so that no range stretching occurs and coloring works as expected.
 
@@ -32,8 +34,16 @@ class SLALevel(float, Enum):
     _MAX = 1.0
 
 
-# SLALevelColumn represents SLALevel single column in connectin matrix
+# SLALevelColumn represents SLALevel single column in connection matrix
 SLALevelColumn = List[Optional[SLALevel]]
+
+
+def agent_label(agent: Agent) -> str:
+    return f"{agent.alias} [{agent.id}]"
+
+
+def agent_id_from_label(label: str) -> AgentID:
+    return AgentID(label.split("[")[1].split("]")[0])
 
 
 class MatrixView:
@@ -45,7 +55,7 @@ class MatrixView:
         self._agents = Agents()
         self._color_scale = self._make_color_scale()
 
-    def make_layout(self, mesh: MeshResults, metric: MetricType, config: Config) -> html.Div:
+    def make_layout(self, mesh: MeshResults, metric: MetricType) -> html.Div:
         title = "SLA Dashboard"
         if mesh.connection_matrix.num_connections_with_health_data() > 0:
             content = self.make_matrix_content(mesh, metric)
@@ -61,8 +71,8 @@ class MatrixView:
 
     def make_matrix_content(self, mesh: MeshResults, metric: MetricType) -> List:
         self._agents = mesh.agents  # remember agents used to make the layout for further processing
-        timestamp_low_ISO = mesh.utc_timestamp_low.isoformat() if mesh.utc_timestamp_low else None
-        timestamp_high_ISO = mesh.utc_timestamp_high.isoformat() if mesh.utc_timestamp_high else None
+        timestamp_low_iso = mesh.utc_timestamp_low.isoformat() if mesh.utc_timestamp_low else None
+        timestamp_high_iso = mesh.utc_timestamp_high.isoformat() if mesh.utc_timestamp_high else None
         fig = self.make_figure(mesh, metric)
 
         return [
@@ -73,14 +83,14 @@ class MatrixView:
                         "<test_results_timestamp_low>",
                         className="header-timestamp",
                         id="timestamp-low",
-                        title=timestamp_low_ISO,
+                        title=timestamp_low_iso,
                     ),
                     html.Span(" - ", className="header-timestamp"),
                     html.Span(
                         "<test_results_timestamp_high>",
                         className="header-timestamp",
                         id="timestamp-high",
-                        title=timestamp_high_ISO,
+                        title=timestamp_high_iso,
                     ),
                 ],
                 className="header__subTitle",
@@ -154,7 +164,7 @@ class MatrixView:
         return {"data": [data], "layout": layout}
 
     def make_figure_data(self, mesh: MeshResults, metric: MetricType) -> Dict:
-        x_labels = [mesh.agents.get_by_id(agent_id).alias for agent_id in mesh.agents.sorted_ids]
+        x_labels = [agent_label(mesh.agents.get_by_id(agent_id)) for agent_id in mesh.agents.sorted_ids]
         y_labels = list(reversed(x_labels))
         sla_levels = self.make_sla_levels(mesh, metric)
         return dict(
@@ -171,30 +181,27 @@ class MatrixView:
             colorscale=self._color_scale,
         )
 
-    def make_sla_levels(self, mesh: MeshResults, type: MetricType) -> List[SLALevelColumn]:
-        thresholds = self.get_thresholds(type)
+    def make_sla_levels(self, mesh: MeshResults, metric_type: MetricType) -> List[SLALevelColumn]:
+        thresholds = self.get_thresholds(metric_type)
         sla_levels: List[SLALevelColumn] = []
 
         for from_id in reversed(mesh.agents.sorted_ids):
             sla_levels_col: SLALevelColumn = []
-            for to_id in mesh.agents.sorted_ids:
+            for i, to_id in enumerate(mesh.agents.sorted_ids):
                 if from_id == to_id:
-                    continue
-                warning = thresholds.warning(from_id, to_id)
-                critical = thresholds.critical(from_id, to_id)
-                health = mesh.connection(from_id, to_id).latest_measurement
-                if health:
-                    metric = health.get_metric(type)
-                    sla_level = self.get_sla_level(metric.value, warning, critical)
+                    sla_level = SLALevel(i % 2)
                 else:
-                    sla_level = SLALevel.NODATA
+                    warning = thresholds.warning(from_id, to_id)
+                    critical = thresholds.critical(from_id, to_id)
+                    health = mesh.connection(from_id, to_id).latest_measurement
+                    if health:
+                        metric = health.get_metric(metric_type)
+                        sla_level = self.get_sla_level(metric.value, warning, critical)
+                    else:
+                        sla_level = SLALevel.NODATA
                 sla_levels_col.append(sla_level)
             sla_levels.append(sla_levels_col)
 
-        # mark matrix diagonal, use alternating SLALevel._MIN and SLALevel._MAX
-        # to ensure matrix contains values in full range 0..1 - to match the color scale
-        for i in range(len(mesh.agents.sorted_ids)):
-            sla_levels[-(i + 1)].insert(i, SLALevel(i % 2))
         return sla_levels
 
     def get_thresholds(self, metric: MetricType) -> Thresholds:
@@ -209,23 +216,33 @@ class MatrixView:
         annotations: List[Dict] = []
         for from_id in reversed(mesh.agents.sorted_ids):
             for to_id in mesh.agents.sorted_ids:
-                if from_id == to_id:
-                    continue
                 from_agent = mesh.agents.get_by_id(from_id)
                 to_agent = mesh.agents.get_by_id(to_id)
-                health = mesh.connection(from_agent.id, to_agent.id).latest_measurement
-                text = cls.format_health(metric, health, False, "")
+                if from_id == to_id:
+                    text = ""
+                else:
+                    health = mesh.connection(from_agent.id, to_agent.id).latest_measurement
+                    text = cls.format_health(metric, health, False, "")
                 annotations.append(
-                    dict(showarrow=False, text=text, xref="x", yref="y", x=to_agent.alias, y=from_agent.alias)
+                    dict(
+                        showarrow=False,
+                        text=text,
+                        xref="x",
+                        yref="y",
+                        x=agent_label(to_agent),
+                        y=agent_label(from_agent),
+                    )
                 )
         return annotations
 
     @staticmethod
-    def format_health(type: MetricType, health: Optional[HealthItem], include_unit: bool = False, nan="N/A") -> str:
+    def format_health(
+        metric_type: MetricType, health: Optional[HealthItem], include_unit: bool = False, nan="N/A"
+    ) -> str:
         if not health:
             return nan
 
-        metric = health.get_metric(type)
+        metric = health.get_metric(metric_type)
         if math.isnan(metric.value):
             return nan
 
@@ -237,28 +254,25 @@ class MatrixView:
         for from_id in reversed(mesh.agents.sorted_ids):
             column_hover_text: List[str] = []
             for to_id in mesh.agents.sorted_ids:
-                if from_id == to_id:
-                    continue
-                text = self.make_cell_hover_text(from_id, to_id, mesh)
-                column_hover_text.append(text)
+                column_hover_text.append(self.make_cell_hover_text(from_id, to_id, mesh))
             matrix_hover_text.append(column_hover_text)
-
-        # insert blank diagonal into matrix
-        for i in range(len(mesh.agents.sorted_ids)):
-            matrix_hover_text[-(i + 1)].insert(i, "")
 
         return matrix_hover_text
 
-    def make_cell_hover_text(self, from_agent_id, to_agent_id: AgentID, mesh: MeshResults) -> str:
+    def make_cell_hover_text(self, from_agent_id: AgentID, to_agent_id: AgentID, mesh: MeshResults) -> str:
+        if from_agent_id == to_agent_id:
+            return ""
         from_agent = mesh.agents.get_by_id(from_agent_id)
         to_agent = mesh.agents.get_by_id(to_agent_id)
         conn = mesh.connection(from_agent.id, to_agent.id)
         distance_unit = self._config.distance_unit
         distance = calc_distance(from_agent.coords, to_agent.coords, distance_unit)
 
-        cell_hover_text: List[str] = []
-        cell_hover_text.append(f"{from_agent.alias} -> {to_agent.alias}")
-        cell_hover_text.append(f"Distance: {distance:.0f} {distance_unit.value}")
+        cell_hover_text: List[str] = [
+            f"From: {from_agent.name}, {from_agent.alias} [{from_agent.id}]",
+            f"To: {to_agent.name}, {to_agent.alias} [{from_agent.id}]",
+            f"Distance: {distance:.0f} {distance_unit.value}",
+        ]
 
         health = conn.latest_measurement
         if health:
@@ -281,6 +295,7 @@ class MatrixView:
             return SLALevel.WARNING
         return SLALevel.CRITICAL
 
+    # noinspection PyProtectedMember
     def _make_color_scale(self) -> List[Tuple[SLALevel, MatrixCellColor]]:
         healthy = self._config.matrix.cell_color_healthy
         warning = self._config.matrix.cell_color_warning
@@ -297,9 +312,12 @@ class MatrixView:
             (SLALevel._MAX, diagonal),
         ]
 
-    def get_agents_from_click(self, clickData: Optional[Dict[str, Any]]) -> Tuple[Optional[AgentID], Optional[AgentID]]:
-        if clickData is None:
+    @staticmethod
+    def get_agents_from_click(click_data: Optional[Dict[str, Any]]) -> Tuple[Optional[AgentID], Optional[AgentID]]:
+        if click_data is None:
             return None, None
 
-        to_agent_alias, from_agent_alias = clickData["points"][0]["x"], clickData["points"][0]["y"]
-        return self._agents.get_by_alias(from_agent_alias).id, self._agents.get_by_alias(to_agent_alias).id
+        to_agent_id = agent_id_from_label(click_data["points"][0]["x"])
+        from_agent_id = agent_id_from_label(click_data["points"][0]["y"])
+        logging.debug("click: from: %s to: %s", from_agent_id, to_agent_id)
+        return from_agent_id, to_agent_id

--- a/presentation/matrix_view.py
+++ b/presentation/matrix_view.py
@@ -1,5 +1,4 @@
 import logging
-
 import math
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
Root cause of the problem is duplication in `x` and `y` labels in the matrix. Plotly ignores rows and colums with duplicate labels.

This fix makes labels unique, unfortunately at the cost of having to parse them to get agent ID from click data.
Labels also became longer, which further complicates display of large matrices.

Change also includes minor formatting and PEP8 violation fixes.

Possibly better fix: replace Plotly heatmap with HTML table
