### PR TITLE
Agent names fixed again

### DIFF
--- a/domain/model/agents.py
+++ b/domain/model/agents.py
@@ -65,8 +65,10 @@ class Agents:
         Update agent names and aliases based on row data while preserving other existing agent attributes
         NOTE: This is an ugly hack that should be removed as soon as Kentik API becomes little bit more consistent
         """
+        logger.debug("update_names_aliases: src_agents: %d", src.count)
         for src_agent in src.all():
             agent = self.get_by_id(src_agent.id)
+            logger.debug("Updating agent id: %s (old name: %s new name: %s)", agent.id, agent.name, src_agent.name)
             if agent.id == AgentID():
                 agent = src_agent
                 logging.warning("Agent %s (name: %s) was not in cache", agent.id, agent.name)

--- a/domain/model/mesh_results.py
+++ b/domain/model/mesh_results.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
-from domain.geo import Coordinates
 from domain.metric import Metric, MetricType, MetricValue
 from domain.model.agents import Agent, Agents
 from domain.types import IP, AgentID, TaskID
@@ -232,10 +231,9 @@ class MeshResults:
     ) -> None:
         self.tasks = tasks
         rows = rows or []
-        agents = Agents()
+        self.participating_agents = Agents()
         for r in rows:
-            agents.insert(r.agent)
-        self.participating_agents = agents
+            self.participating_agents.insert(r.agent)
         self.connection_matrix = ConnectionMatrix(rows)
 
     def incremental_update(self, src: MeshResults) -> None:
@@ -243,6 +241,7 @@ class MeshResults:
 
         self.tasks.incremental_update(src.tasks)
         self.connection_matrix.incremental_update(src.connection_matrix)
+        self.participating_agents = src.participating_agents
 
     def filter(self, from_agent, to_agent: AgentID, metric_type: MetricType) -> List[Tuple[datetime, MetricValue]]:
         items = self.connection(from_agent, to_agent).health

--- a/infrastructure/data_access/http/synthetics_repo.py
+++ b/infrastructure/data_access/http/synthetics_repo.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 
 from domain.metric import MetricValue
 from domain.model import Agent, Agents, HealthItem, MeshColumn, MeshConfig, MeshResults, MeshRow, Task, Tasks
-from domain.model.mesh_results import Coordinates
+from domain.geo import Coordinates
 from domain.types import AgentID, TaskID, TestID
 
 # the below "disable=E0611" is needed as we don't commit the generated code into git repo and thus CI linter complains

--- a/infrastructure/data_access/http/synthetics_repo.py
+++ b/infrastructure/data_access/http/synthetics_repo.py
@@ -2,9 +2,9 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
+from domain.geo import Coordinates
 from domain.metric import MetricValue
 from domain.model import Agent, Agents, HealthItem, MeshColumn, MeshConfig, MeshResults, MeshRow, Task, Tasks
-from domain.geo import Coordinates
 from domain.types import AgentID, TaskID, TestID
 
 # the below "disable=E0611" is needed as we don't commit the generated code into git repo and thus CI linter complains

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ target-version = ['py37']
 [tool.isort]
 profile = "black"
 known_local_folder = ["domain", "generated", "infrastructure", "presentation"]
+skip_glob = "generated/*"
 line_length = 120


### PR DESCRIPTION
Make sure that agent names are sourced from the `mesh` section in augmented Health API results.
This was broken by refactor of data retrieval which failed to copy `MeshResult.participating_agents` in `MeshResults.incremental_update`.
Also removed some unused imports.