### PR TITLE
More compact layout of matrix view

### DIFF
--- a/data/assets/03_global.css
+++ b/data/assets/03_global.css
@@ -12,7 +12,7 @@ body {
 /* Text headers */
 h1 {
   color: var(--theme-0);
-  font-size: var(--font-size-xlarge);
+  font-size: var(--font-size-large);
 }
 h2 {
   color: var(--theme-0);
@@ -26,24 +26,46 @@ h3 {
 }
 
 /* Page top horizontal bar */
-.header_main {
+.main_header {
+  font-size: var(--font-size-large);
   background: var(--blue-0);
-  color: var(--blue-4);
+  color: var(--white-0);
   text-align: center;
-  padding: 20px 0 20px;
-  box-shadow: 0 0 20px 0 var(--theme-3);
-  margin-bottom: 0;
-  padding: 0 0 0 0;
+  padding-top: 20px;
+  padding-bottom: 40px;
+}
+
+.header_title {
+  width: 20%;
+  float: left;
 }
 
 /* Text directly below the top bar; timestamp */
-.header__subTitle{
-  width: 100%;
+.time_range {
+  width: 60%;
+  float: left;
+}
+
+.metric_selector {
+  font-size: var(--font-size-medium);
+  width: 20%;
+  float: left;
 }
 
 /* Space containing all the elements, as opposed to the unused space on the left and right side */
 .main_container{
   text-align: center;
-  padding: 30px;
   background-color: var(--white-0);
+  padding: 10px;
+}
+
+/* time series view header formatting */
+.time_series_header_label {
+  text-align: right;
+  padding-left: 20px;
+}
+
+.time_series_header_value {
+  text-align: left;
+  padding-left: 20px;
 }

--- a/data/assets/07_matrix_view.css
+++ b/data/assets/07_matrix_view.css
@@ -1,5 +1,5 @@
 :root {
-  --matrix-border-color: lightgray;
+  --matrix-border-color: white;
   --matrix-agent-bg-color: #eeeeee;
   --matrix-diagonal-bg-color: white;
   --matrix-data-width: 150px;
@@ -29,16 +29,16 @@
 }
 
 .td-from-agent {
-  font-weight: bold;
+  font-weight: medium;
   background-color: var(--matrix-agent-bg-color);
   border:1px solid var(--matrix-border-color);
   border-collapse: collapse;
   text-align: right;
-  padding: 0 4px 0 4px;
+  padding: 4px 4px 4px 4px;
 }
 
 .td-to-agent {
-  font-weight: bold;
+  font-weight: medium;
   background-color: var(--matrix-agent-bg-color);
   text-align: left;
   border:1px solid var(--matrix-border-color);
@@ -47,7 +47,7 @@
   max-width: var(--matrix-data-width);
   vertical-align: bottom;
   text-align: center;
-  padding: 0px 4px 4px 4px;
+  padding: 4px 4px 4px 4px;
 }
 
 .tr-connection-matrix {


### PR DESCRIPTION
Included in this PR:
- moving metric selector and time range display to header in the matrix view
- removing bold font from matrix row/column headings
- making borders in the matrix white and adding little bit of vertical padding in order to improve readbility of long rows
- putting information in the time series view header in a tabular format
- adding titles to Y-axis in time-series graphs
- making CSS classnames more self-explanatory