### PR TITLE
Remove config param that doesnt apply to gthread worker class

### DIFF
--- a/data/gunicorn.conf.py
+++ b/data/gunicorn.conf.py
@@ -3,8 +3,7 @@
 import multiprocessing
 
 wsgi_app = "main:run()"
-workers = 1
-worker_connections = 100
+workers = 1  # only one worker process to maximize mesh results caching profits
 bind = ":8050"
 timeout = 30
 # Worker is changed to prevent worker timeouts


### PR DESCRIPTION
"worker_connections" is not used when worker_class is "gthread"